### PR TITLE
Add zstd to external_targets

### DIFF
--- a/recipes/llvm/all/conanfile.py
+++ b/recipes/llvm/all/conanfile.py
@@ -556,6 +556,7 @@ class Llvm(ConanFile):
         external_targets = {
             'libffi::libffi': 'ffi',
             'ZLIB::ZLIB': 'z',
+            'zstd::zstdlib': 'zstd',
             'Iconv::Iconv': 'iconv',
             'libxml2::libxml2': 'xml2',
             'pthread': 'pthread',
@@ -701,6 +702,10 @@ class Llvm(ConanFile):
             if not 'z' in components['LLVMSupport']:
                 components['LLVMSupport'].append('z')
 
+        if self.options.get_safe('with_zstd', False):
+            if not 'zstd' in components['LLVMSupport']:
+                components['LLVMSupport'].append('zstd')
+
         # fix: ERROR: llvm/14.0.6@...: Required package 'libxml2' not in component 'requires'
         xml2_linking = ["LLVMWindowsManifest", "lldbHost", "c-index-test"]
         report_xml2_issue = self.options.with_xml2
@@ -749,6 +754,7 @@ class Llvm(ConanFile):
         external_targets = {
             'ffi': 'libffi::libffi',
             'z': 'zlib::zlib',
+            'zstd': 'zstd::zstdlib',
             'xml2': 'libxml2::libxml2',
             'iconv': 'Iconv::Iconv',
         }


### PR DESCRIPTION
I tried to build llvm/16.0.6 with `-o with_project_clang=True -o with_project_clang-tools-extra=True` but failed. The error message says `Required package 'zstd' not in component 'requires'`.

This modification seems to fix the error, but I'm not so sure whether this is correct enough.

my conan profile:

```
[settings]
arch=armv8
build_type=Release
compiler=clang
compiler.cppstd=20
compiler.libcxx=libc++
compiler.version=17
os=Macos

[options]
llvm/*:with_project_clang=True
llvm/*:with_project_clang-tools-extra=True
llvm/*:llvm_build_llvm_dylib=True
llvm/*:llvm_link_llvm_dylib=True
```